### PR TITLE
Bug/master vs main

### DIFF
--- a/02-localproject.Rmd
+++ b/02-localproject.Rmd
@@ -165,6 +165,17 @@ We could just make these changes one at a time as before, but if we want someone
 
 So far we've just been working on the "master" branch - that's what the cyan text is all about - which you can think of as more of a trunk than a branch, it's what we'd regard of as the most up to date and complete version of the code. Let's make a new branch for our unit conversion work.
 
+:::: {.infoboxblue .info data-latex=”info”}
+
+**"master" branch vs "main" branch**
+
+We have just referred to the "master" branch. Whilst this is still the git default, conventions are moving towards use of "main" branch instead of "master" branch. Unlike the word master, the word main does not have negative association with the slave trade.
+
+This guide will refer to the "master" branch for specific examples where consistency with the git default is important and the "main" branch in other circumstances.
+
+::::
+
+
 To create a new branch type in
 ```sh
 git branch unit_conversion

--- a/02-localproject.Rmd
+++ b/02-localproject.Rmd
@@ -172,6 +172,9 @@ So far we've just been working on the "master" branch - that's what the cyan tex
 We have just referred to the "master" branch. Whilst this is still the git default, conventions are moving towards use of "main" branch instead of "master" branch. Unlike the word master, the word main does not have negative association with the slave trade.
 
 This guide will refer to the "master" branch for specific examples where consistency with the git default is important and the "main" branch in other circumstances.
+Note the two terms refer to the same thing but they are not interchangeable.
+A project will have either a main or a master branch, depending on how it was set-up, but not both.
+You should work out which yours has and use that in place of main/master for all examples in this book.
 
 ::::
 

--- a/03-vsts-overview.Rmd
+++ b/03-vsts-overview.Rmd
@@ -21,7 +21,7 @@ VSTS offers unlimited private repositories for 5 users. If you sign up via your 
 
 At a high level when you are using VSTS (or any type of remote) you are creating a central copy of your code on a server (the VSTS site). 
 
-The aim of any project is to get your final complete code on to the master branch of the server copy. Analysts will still make and run all their changes locally but will then use the concepts of *pushing*, *pulling* and *pull requesting* to get the VSTS version up to date.
+The aim of any project is to get your final complete code on to the main/master branch of the server copy. Analysts will still make and run all their changes locally but will then use the concepts of *pushing*, *pulling* and *pull requesting* to get the VSTS version up to date.
 
 Having this central repository and the approval processes that VSTS provides means that multiple analysts can work on a project at the same time and systematically merge all their changes into the final version after code review.
 
@@ -113,11 +113,11 @@ The following clip outlines this process:
 
 ## Branch Policies
 
-At this point you will have a project that anyone who is a member of has the ability to push directly to the master branch. 
+At this point you will have a project that anyone who is a member of has the ability to push directly to the main/master branch. 
 
-This resource is promoting a workflow in which code is reviewed throughout the development life cycle. Pushing to master doesn't allow this directly. 
+This resource is promoting a workflow in which code is reviewed throughout the development life cycle. Pushing to main/master doesn't allow this directly. 
 
-Instead what we do is set **Branch Policies** which force code to be reviewed in VSTS before it can be merged into master. 
+Instead what we do is set **Branch Policies** which force code to be reviewed in VSTS before it can be merged into main/master. 
 
 This comes with various options which are summarised below:
 

--- a/04-overall-workflow.Rmd
+++ b/04-overall-workflow.Rmd
@@ -27,7 +27,7 @@ git push -u origin --all <repo_URL>
 
 - Work may be assigned to you as a "Work Item". In DevOps use the link to make new branch. To correct a bug, prefix the branch name with "bug/". To add new functionality, prefix the branch name with "feature/".
 
-- Make sure your master branch is up to date.
+- Make sure your main branch is up to date.
 ```sh 
 git pull
 ```
@@ -52,21 +52,29 @@ git commit -m "Commit message"
 ```
 
 ## Merging
-- When you've made enough changes to complete your work item checkout the master 
+:::: {.infoboxblue .info data-latex=”info”}
+
+**Reminder: "master" branch vs "main" branch**
+
+Repositories usually have either a "main" or a "master" branch. The two terms refer to the same thing but "main" is considered more inclusive language. Our examples in this chapter will refer to a "main" branch rather than a "master" one.
+
+::::
+
+- When you've made enough changes to complete your work item checkout the main 
 branch in your local repository do a pull in case anyone else had made changes.
 ```sh 
-git checkout master
+git checkout main
 ```
 ```sh 
 git pull
 ```
 
-- Switch back to your working branch. Merge any changes from master.
+- Switch back to your working branch. Merge any changes from main.
 ```sh 
 git checkout <your_branch_name>
 ```
 ```sh 
-git merge master
+git merge main
 ```
 
 - Sort out any merge conflicts.
@@ -74,9 +82,9 @@ git merge master
 git status
 ``` will list the files that have merge conflicts. Open the files with 
 the conflicts, and search them for "<<<<". Everything from the next line up until 
-a line of "====" will be from the master branch. Everything from the "====" line 
+a line of "====" will be from the main branch. Everything from the "====" line 
 until ">>>>" will be from your working branch. Work through the code to make sure 
-that you keep all the necessary changes. There may be changes from master and your branch that you want to keep, so don't just idly delete things!
+that you keep all the necessary changes. There may be changes from main and your branch that you want to keep, so don't just idly delete things!
 Add and commit the changes.
 ```sh 
 git add <file_to_be_merged>
@@ -96,6 +104,6 @@ git push
 
 - Have someone review your work. If any changes are required, go back to [Making Changes](#making-changes) and work from there again.
 
-- Merge your branch into Master
+- Merge your branch into main
 
 - Find some more work, go back to the top and start again, Sisyphus!


### PR DESCRIPTION
It is now considered better to have main branch rather than a master one and this is what DevOps repos now default to. https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main

This pull request:
1. Adds an explanation that the two approaches can be used interchangeably.
2. Retains master when used relating to a specific example starting with `git init` because this is what `git init` uses.
3. Updates to main rather than master in later examples.

**Review asks:**
1. From the added text, can you tell the difference between main and master?
2. Are there any other examples you think should be changed.